### PR TITLE
chore: remove gpt-oss-120b-free

### DIFF
--- a/clients/swift/Sources/main.swift
+++ b/clients/swift/Sources/main.swift
@@ -36,7 +36,7 @@ struct TinfoilExample {
                 messages: [
                     .user(.init(content: .string("Say hello in exactly 5 words.")))
                 ],
-                model: "gpt-oss-120b-free"
+                model: "gpt-oss-120b"
             )
 
             print("--- Streaming Response ---")
@@ -53,7 +53,7 @@ struct TinfoilExample {
         } catch TinfoilError.missingAPIKey {
             print("Error: API key not found.")
             print("Set the TINFOIL_API_KEY environment variable:")
-            print("  export TINFOIL_API_KEY=tk-your-key-here")
+            print("  export TINFOIL_API_KEY=<YOUR_API_KEY>")
 
         } catch {
             print("Error: \(error)")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the Swift example to the active `gpt-oss-120b` model and updated the API key instructions, removing the deprecated `gpt-oss-120b-free` reference. This prevents failed requests and reduces confusion when setting up the client.

<sup>Written for commit 4bb83635554cce940f41719eaa3cda5feb7420cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

